### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ More welcome, open an issue or a PR!
 import Ember from 'ember';
 import {
   SUPPORTS_NEW_COMPUTED
-} from 'ember-compatibility-helpers;
+} from 'ember-compatibility-helpers';
 
 const { computed, Component } = Ember
 


### PR DESCRIPTION
This lead to some weird highlighting in the Github frontend:
![image](https://user-images.githubusercontent.com/1325249/30472981-ea3c1b0a-99fe-11e7-90c8-db994929a572.png)

Nice addon btw! 👏