### PR TITLE
bugfix(build): Fixes the case where the addon has been included more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     this._super.init.apply(this, arguments);
 
     // Create a root level version checker for checking the Ember version later on
-    this.emberVersion = new VersionChecker(project).forEmber().version;
+    this.emberVersion = new VersionChecker({ project, root: project.root }).forEmber().version;
 
     // Create a parent checker for checking the parent app/addons dependencies (for things like polyfills)
     this.parentChecker = new VersionChecker(parent);

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -19,6 +19,10 @@ let EmberBabelAddon = CoreObject.extend(EmberBabelMixin);
 
 function itShouldReplace(flagName, value, libs) {
   return it(`should replace ${flagName} correctly`, co.wrap(function* () {
+    for (let lib in libs) {
+      mockPackage.mock(lib, libs[lib]);
+    }
+
     const project = { root: process.cwd() };
     const ui = new MockUI();
 
@@ -27,12 +31,7 @@ function itShouldReplace(flagName, value, libs) {
       parent: project,
     });
 
-    const addon = new Addon({
-      project,
-      app: project,
-      parent: project,
-      ui: this.ui,
-    });
+    const addon = new Addon(project, project);
 
     const input = yield createTempDir();
 
@@ -40,11 +39,7 @@ function itShouldReplace(flagName, value, libs) {
       'foo.js': `import { ${flagName} } from 'ember-compatibility-helpers'; if (${flagName}) { console.log('hello, world!'); }`
     });
 
-    for (let lib in libs) {
-      mockPackage.mock(lib, libs[lib]);
-    }
-
-    addon.included();
+    addon.included(project);
     const subject = babelAddon.transpileTree(input.path());
     const output = createBuilder(subject);
 


### PR DESCRIPTION
The included hook only runs once per instance of the addon in the dependency graph. The babel transforms we are adding, however, are meant to be added to each addon that includes this addon as a dependency, as well as the root app. Because each addon has it's own version of `ember-cli-babel`, we have to make sure it happens for each of them.

To do this, we use the `init` hook instead of the `included` hook, since it runs each time the addon is created. Unfortunately, the `init` hook does not have any way to access the root app - that is only provided in the `included` hook. So, we still need to use `included` for the case where this addon is being used in an actual app.