### PR TITLE
Avoid `semver.satisfies` when possible.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const VersionChecker = require('ember-cli-version-checker');
 const satisfies = require('semver').satisfies;
+const gte = require('semver').gte;
 
 module.exports = {
   name: 'ember-compatibility-helpers',
@@ -69,22 +70,22 @@ module.exports = {
         name: 'ember-compatibility-helpers',
         source: 'ember-compatibility-helpers',
         flags: {
-          HAS_UNDERSCORE_ACTIONS: !satisfies(trueEmberVersion, '>= 2.0.0'),
-          HAS_MODERN_FACTORY_INJECTIONS: satisfies(trueEmberVersion, '>= 2.13.0'),
+          HAS_UNDERSCORE_ACTIONS: !gte(trueEmberVersion, '2.0.0'),
+          HAS_MODERN_FACTORY_INJECTIONS: gte(trueEmberVersion, '2.13.0'),
           HAS_DESCRIPTOR_TRAP: satisfies(trueEmberVersion, '~3.0.0'),
-          HAS_NATIVE_COMPUTED_GETTERS: satisfies(trueEmberVersion, '>= 3.1.0-beta.1'),
+          HAS_NATIVE_COMPUTED_GETTERS: gte(trueEmberVersion, '3.1.0-beta.1'),
 
-          GTE_EMBER_1_13: satisfies(trueEmberVersion, '>= 1.13.0'),
-          IS_EMBER_2: satisfies(trueEmberVersion, '>= 2.0.0'),
-          IS_GLIMMER_2: satisfies(trueEmberVersion, '>= 2.10.0'),
+          GTE_EMBER_1_13: gte(trueEmberVersion, '1.13.0'),
+          IS_EMBER_2: gte(trueEmberVersion, '2.0.0'),
+          IS_GLIMMER_2: gte(trueEmberVersion, '2.10.0'),
 
-          SUPPORTS_FACTORY_FOR: satisfies(trueEmberVersion, '>= 2.12.0') || parentChecker.for('ember-factory-for-polyfill', 'npm').satisfies('>= 1.0.0'),
-          SUPPORTS_GET_OWNER: satisfies(trueEmberVersion, '>= 2.3.0') || parentChecker.for('ember-getowner-polyfill', 'npm').satisfies('>= 1.1.0'),
-          SUPPORTS_SET_OWNER: satisfies(trueEmberVersion, '>= 2.3.0'),
-          SUPPORTS_NEW_COMPUTED: satisfies(trueEmberVersion, '>= 1.12.0-beta.1'),
-          SUPPORTS_INVERSE_BLOCK: satisfies(trueEmberVersion, '>= 1.13.0'),
-          SUPPORTS_CLOSURE_ACTIONS: satisfies(trueEmberVersion, '>= 1.13.0'),
-          SUPPORTS_UNIQ_BY_COMPUTED: satisfies(trueEmberVersion, '>= 2.7.0')
+          SUPPORTS_FACTORY_FOR: gte(trueEmberVersion, '2.12.0') || parentChecker.for('ember-factory-for-polyfill', 'npm').gte('1.0.0'),
+          SUPPORTS_GET_OWNER: gte(trueEmberVersion, '2.3.0') || parentChecker.for('ember-getowner-polyfill', 'npm').gte('1.1.0'),
+          SUPPORTS_SET_OWNER: gte(trueEmberVersion, '2.3.0'),
+          SUPPORTS_NEW_COMPUTED: gte(trueEmberVersion, '1.12.0-beta.1'),
+          SUPPORTS_INVERSE_BLOCK: gte(trueEmberVersion, '1.13.0'),
+          SUPPORTS_CLOSURE_ACTIONS: gte(trueEmberVersion, '1.13.0'),
+          SUPPORTS_UNIQ_BY_COMPUTED: gte(trueEmberVersion, '2.7.0')
         }
       },
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -86,6 +86,7 @@ describe('ember-compatibility-helpers', function() {
 
   itShouldReplace('HAS_UNDERSCORE_ACTIONS', true, { 'ember-source': '1.10.0' });
   itShouldReplace('HAS_UNDERSCORE_ACTIONS', false, { 'ember-source': '2.0.0' });
+  itShouldReplace('HAS_UNDERSCORE_ACTIONS', false, { 'ember-source': '2.2.0-beta.3' });
 
   itShouldReplace('HAS_MODERN_FACTORY_INJECTIONS', true, { 'ember-source': '2.13.0' });
   itShouldReplace('HAS_MODERN_FACTORY_INJECTIONS', false, { 'ember-source': '2.12.0' });
@@ -101,6 +102,7 @@ describe('ember-compatibility-helpers', function() {
   itShouldReplace('GTE_EMBER_1_13', true, { 'ember-source': '1.13.0' });
   itShouldReplace('GTE_EMBER_1_13', false, { 'ember-source': '1.11.0' });
 
+  itShouldReplace('IS_EMBER_2', true, { 'ember-source': '2.4.0-beta.1' });
   itShouldReplace('IS_EMBER_2', true, { 'ember-source': '2.0.0' });
   itShouldReplace('IS_EMBER_2', false, { 'ember-source': '1.13.0' });
 


### PR DESCRIPTION
tldr;

```
> let semver = require('semver')
 undefined
> semver.satisfies('3.5.0-beta.1', '>= 3.4.0-beta.1')
false
> semver.gte('3.5.0-beta.1', '3.4.0-beta.1')
true
```

From https://www.npmjs.com/package/semver#prerelease-tags:

> If a version has a prerelease tag (for example, 1.2.3-alpha.3) then it will only be allowed to satisfy comparator sets if at least one comparator with the same [major, minor, patch] tuple also has a prerelease tag.
> 
> For example, the range >1.2.3-alpha.3 would be allowed to match the version 1.2.3-alpha.7, but it would not be satisfied by 3.4.5-alpha.9, even though 3.4.5-alpha.9 is technically "greater than" 1.2.3-alpha.3 according to the SemVer sort rules. The version range only accepts prerelease tags on the 1.2.3 version. The version 3.4.5 would satisfy the range, because it does not have a prerelease flag, and 3.4.5 is greater than 1.2.3-alpha.7.
>
> The purpose for this behavior is twofold. First, prerelease versions frequently are updated very quickly, and contain many breaking changes that are (by the author's design) not yet fit for public consumption. Therefore, by default, they are excluded from range matching semantics.
>
> Second, a user who has opted into using a prerelease version has clearly indicated the intent to use that specific set of alpha/beta/rc versions. By including a prerelease tag in the range, the user is indicating that they are aware of the risk. However, it is still not appropriate to assume that they have opted into taking a similar risk on the next set of prerelease versions.