### PR TITLE
Add support for dynamic `gte` / `lte` imports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ function comparisonPlugin(babel) {
             path.scope.rename(path.node.local.name, state.gteImportId.name);
             path.remove();
           }
+
+          if (importedName === 'lte') {
+            state.lteImportId = state.lteImportId || path.scope.generateUidIdentifierBasedOnNode(path.node.id);
+            path.scope.rename(path.node.local.name, state.lteImportId.name);
+            path.remove();
+          }
         }
       },
 
@@ -29,6 +35,11 @@ function comparisonPlugin(babel) {
         if (state.gteImportId && path.node.callee.name === state.gteImportId.name) {
           let argument = path.node.arguments[0];
           let replacementIdentifier = semver.gte(state.opts.emberVersion, argument.value) ? trueIdentifier : falseIdentifier;
+
+          path.replaceWith(replacementIdentifier);
+        } else if (state.lteImportId && path.node.callee.name === state.lteImportId.name) {
+          let argument = path.node.arguments[0];
+          let replacementIdentifier = semver.lte(state.opts.emberVersion, argument.value) ? trueIdentifier : falseIdentifier;
 
           path.replaceWith(replacementIdentifier);
         }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,43 @@
 'use strict';
 
 const VersionChecker = require('ember-cli-version-checker');
-const satisfies = require('semver').satisfies;
-const gte = require('semver').gte;
+const semver = require('semver');
+const satisfies = semver.satisfies;
+const gte = semver.gte;
+
+function comparisonPlugin(babel) {
+  const t = babel.types;
+
+  const trueIdentifier = t.identifier('true');
+  const falseIdentifier = t.identifier('false');
+
+  return {
+    name: "ember-compatibility-helpers",
+    visitor: {
+      ImportSpecifier(path, state) {
+        if (path.parent.source.value === 'ember-compatibility-helpers') {
+          let importedName = path.node.imported.name;
+          if (importedName === 'gte') {
+            state.gteImportId = state.gteImportId || path.scope.generateUidIdentifierBasedOnNode(path.node.id);
+            path.scope.rename(path.node.local.name, state.gteImportId.name);
+            path.remove();
+          }
+        }
+      },
+
+      CallExpression(path, state) {
+        if (state.gteImportId && path.node.callee.name === state.gteImportId.name) {
+          let argument = path.node.arguments[0];
+          let replacementIdentifier = semver.gte(state.opts.emberVersion, argument.value) ? trueIdentifier : falseIdentifier;
+
+          path.replaceWith(replacementIdentifier);
+        }
+      }
+    }
+  };
+}
+
+comparisonPlugin.baseDir = () => __dirname;
 
 module.exports = {
   name: 'ember-compatibility-helpers',
@@ -46,10 +81,17 @@ module.exports = {
 
     const plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
     const debugPlugin = this._getDebugPlugin(this.emberVersion, this.parentChecker);
+    const comparisonPlugin = this._getComparisonPlugin(this.emberVersion);
 
-    plugins.push(debugPlugin);
+    plugins.push(debugPlugin, comparisonPlugin);
 
     this._registeredWithBabel = true;
+  },
+
+  _getComparisonPlugin() {
+    const trueEmberVersion = this.emberVersion.match(/\d+\.\d+\.\d+/)[0];
+
+    return [comparisonPlugin, { emberVersion: trueEmberVersion }];
   },
 
   _getDebugPlugin(emberVersion, parentChecker) {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -187,5 +187,6 @@ describe('ember-compatibility-helpers', function() {
 
   describe('function replacement', function() {
     itShouldReplaceFunction('gte', 'gte("3.0.0")', false, { 'ember-source': '2.13.0' });
+    itShouldReplaceFunction('lte', 'lte("3.0.0")', true, { 'ember-source': '2.13.0' });
   });
 });

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -116,6 +116,13 @@ function itShouldReplaceFunction(importName, invocation, expectedValue, libs) {
     expectedOutput: `define('foo', [], function () {\n  'use strict';\n\n  if (${String(expectedValue)}) {\n    console.log('hello, world!');\n  }\n});`,
     libraries: libs
   });
+
+  itTransforms({
+    description: `should replace ${importName} when used as \`const HAS_BLAH=${invocation}\` correctly`,
+    input: `import { ${importName} } from 'ember-compatibility-helpers'; var HAS_BLAH = ${invocation}; if (HAS_BLAH) { console.log('hello, world!'); }`,
+    expectedOutput: `define('foo', [], function () {\n  'use strict';\n\n  var HAS_BLAH = ${String(expectedValue)};if (HAS_BLAH) {\n    console.log('hello, world!');\n  }\n});`,
+    libraries: libs
+  });
 }
 
 describe('ember-compatibility-helpers', function() {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -109,6 +109,15 @@ function itShouldReplace(flagName, value, libs) {
   });
 }
 
+function itShouldReplaceFunction(importName, invocation, expectedValue, libs) {
+  itTransforms({
+    description: `should replace ${importName} when used as \`if(${invocation}) {}\` correctly`,
+    input: `import { ${importName} } from 'ember-compatibility-helpers'; if (${invocation}) { console.log('hello, world!'); }`,
+    expectedOutput: `define('foo', [], function () {\n  'use strict';\n\n  if (${String(expectedValue)}) {\n    console.log('hello, world!');\n  }\n});`,
+    libraries: libs
+  });
+}
+
 describe('ember-compatibility-helpers', function() {
   this.timeout(0);
   const root = process.cwd();
@@ -174,5 +183,9 @@ describe('ember-compatibility-helpers', function() {
 
     // Canary
     itShouldReplace('IS_EMBER_2', true, { 'ember-source': '2.16.0-alpha.1-null+c7c04952' });
+  });
+
+  describe('function replacement', function() {
+    itShouldReplaceFunction('gte', 'gte("3.0.0")', false, { 'ember-source': '2.13.0' });
   });
 });


### PR DESCRIPTION
This PR adds support for (and testing of) the following usage:

```js
import { gte } from 'ember-compatibility-helpers';

const HAS_SPECIAL_SAUCE = gte('3.1.0');

if (HAS_SPECIAL_SAUCE) {
  // ...snip...
}
```

Into:

```js
const HAS_SPECIAL_SAUCE = true;

if (HAS_SPECIAL_SAUCE) {
  // ...snip...
}
```

This works by replacing the `gte` and `lte` `CallExpressions` with the literal boolean results at compile time.