### PR TITLE
Add failing test case for ember-cli-babel@6.

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,7 +9,7 @@ module.exports = function() {
         command: 'ember test',
         npm: {
           devDependencies: {
-            'ember-cli-babel': '6.8.0'
+            'ember-cli-babel': '^6.16.0'
           }
         }
       },
@@ -18,7 +18,7 @@ module.exports = function() {
         command: 'mocha node-tests/babel-6/addon-test.js',
         npm: {
           devDependencies: {
-            'ember-cli-babel': '6.8.0'
+            'ember-cli-babel': '^6.16.0'
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "babel-plugin-debug-macros": "^0.2.0-beta.6",
+    "babel-plugin-debug-macros": "^0.2.0",
     "ember-cli-version-checker": "^2.1.1",
     "semver": "^5.4.1"
   },

--- a/tests/unit/gte-smoke-test.js
+++ b/tests/unit/gte-smoke-test.js
@@ -1,0 +1,8 @@
+import { module, test } from 'qunit';
+import { gte } from 'ember-compatibility-helpers';
+
+module('gte-smoke-test', function() {
+  test('gte generally functions, and avoids an import error', function(assert) {
+    assert.ok(gte('0.0.0'));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,9 +967,15 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0-beta.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0-beta.6.tgz#ecdf6e408d5c863ab21740d7ad7f43f027d2f912"
+  resolved "https://codeload.github.com/pzuraq/babel-plugin-debug-macros/tar.gz/5113802ea440e1f6c2e67284a69aad6ef92ae4d9"
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
When using more recent ember-cli-babel versions, the `ember-compatibility-helpers` import is no longer removed. This updates our test suite to show the issue.