### PR TITLE
feat(build): generate TypeScript declaration file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,9 @@ module.exports = {
         'config/**/*.js',
         'tests/dummy/config/**/*.js',
         'node-tests/**/*.js',
-        'comparision-plugin.js'
+        'comparision-plugin.js',
+        'utils/**/*.js',
+        'build/**/*.js'
       ],
       excludedFiles: [
         'app/**',

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+/index.d.ts
 
 # dependencies
 /node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,4 @@ bower.json.ember-try
 package.json.ember-try
 
 /node-tests
+/build

--- a/build/boolean-flags.js
+++ b/build/boolean-flags.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const VersionChecker = require('ember-cli-version-checker');
+const getFlags = require('../utils/get-flags');
+
+/**
+ * Calls the `get-flags` util with mock inputs in order to retrieve the actual
+ * flag keys.
+ */
+module.exports = Object.keys(
+  getFlags('0.0.0', new VersionChecker({ root: __dirname }))
+);

--- a/build/types.js
+++ b/build/types.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const booleanFlags = require('./boolean-flags');
+
+/**
+ * Generates type declarations for the `comparison-plugin` (`gte`, `lte`) and
+ * and the debug plugin (boolean flags).
+ */
+module.exports = [
+  'export function gte(version: string): boolean;',
+  'export function lte(version: string): boolean;'
+]
+  .concat(booleanFlags.map(b => `export const ${b}: boolean;`))
+  .join('\n');

--- a/build/write-declaration-file.js
+++ b/build/write-declaration-file.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const types = require('./types');
+
+fs.writeFileSync(path.resolve(__dirname, '../index.d.ts'), types);

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 const VersionChecker = require('ember-cli-version-checker');
 const extractTrueVersion = require('./utils/extract-true-version');
-const semver = require('semver');
-const satisfies = semver.satisfies;
-const gte = semver.gte;
+const getFlags = require('./utils/get-flags');
 
 module.exports = {
   name: 'ember-compatibility-helpers',
@@ -66,9 +64,6 @@ module.exports = {
   },
 
   _getDebugPlugin(emberVersion, parentChecker) {
-    const trueEmberVersion = extractTrueVersion(emberVersion);
-    const emberDataVersion = parentChecker.for('ember-data', 'npm').version;
-
     const options = {
       debugTools: {
         isDebug: process.env.EMBER_ENV !== 'production',
@@ -79,23 +74,7 @@ module.exports = {
         {
           name: 'ember-compatibility-helpers',
           source: 'ember-compatibility-helpers',
-          flags: {
-            HAS_UNDERSCORE_ACTIONS: !gte(trueEmberVersion, '2.0.0'),
-            HAS_MODERN_FACTORY_INJECTIONS: gte(trueEmberVersion, '2.13.0'),
-            HAS_DESCRIPTOR_TRAP: satisfies(trueEmberVersion, '~3.0.0'),
-            HAS_NATIVE_COMPUTED_GETTERS: gte(trueEmberVersion, '3.1.0-beta.1'),
-
-            IS_GLIMMER_2: gte(trueEmberVersion, '2.10.0'),
-            IS_RECORD_DATA: !emberDataVersion ? false : gte(emberDataVersion, '3.5.0'),
-
-            SUPPORTS_FACTORY_FOR: gte(trueEmberVersion, '2.12.0') || parentChecker.for('ember-factory-for-polyfill', 'npm').gte('1.0.0'),
-            SUPPORTS_GET_OWNER: gte(trueEmberVersion, '2.3.0') || parentChecker.for('ember-getowner-polyfill', 'npm').gte('1.1.0'),
-            SUPPORTS_SET_OWNER: gte(trueEmberVersion, '2.3.0'),
-            SUPPORTS_NEW_COMPUTED: gte(trueEmberVersion, '1.12.0-beta.1'),
-            SUPPORTS_INVERSE_BLOCK: gte(trueEmberVersion, '1.13.0'),
-            SUPPORTS_CLOSURE_ACTIONS: gte(trueEmberVersion, '1.13.0'),
-            SUPPORTS_UNIQ_BY_COMPUTED: gte(trueEmberVersion, '2.7.0')
-          }
+          flags: getFlags(emberVersion, parentChecker)
         }
       ]
     };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests node-tests",
     "start": "ember serve",
     "test": "mocha node-tests/babel-7",
-    "test:all": "ember try:each"
+    "test:all": "ember try:each",
+    "prepack": "node ./build/write-declaration-file"
   },
   "dependencies": {
     "babel-plugin-debug-macros": "^0.2.0",

--- a/utils/get-flags.js
+++ b/utils/get-flags.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const extractTrueVersion = require('./extract-true-version');
+const semver = require('semver');
+const satisfies = semver.satisfies;
+const gte = semver.gte;
+
+module.exports = function(emberVersion, parentChecker) {
+  const trueEmberVersion = extractTrueVersion(emberVersion);
+  const emberDataVersion = parentChecker.for('ember-data', 'npm').version;
+
+  return {
+    HAS_UNDERSCORE_ACTIONS: !gte(trueEmberVersion, '2.0.0'),
+    HAS_MODERN_FACTORY_INJECTIONS: gte(trueEmberVersion, '2.13.0'),
+    HAS_DESCRIPTOR_TRAP: satisfies(trueEmberVersion, '~3.0.0'),
+    HAS_NATIVE_COMPUTED_GETTERS: gte(trueEmberVersion, '3.1.0-beta.1'),
+
+    IS_GLIMMER_2: gte(trueEmberVersion, '2.10.0'),
+    IS_RECORD_DATA: !emberDataVersion ? false : gte(emberDataVersion, '3.5.0'),
+
+    SUPPORTS_FACTORY_FOR:
+      gte(trueEmberVersion, '2.12.0') ||
+      parentChecker.for('ember-factory-for-polyfill', 'npm').gte('1.0.0'),
+    SUPPORTS_GET_OWNER:
+      gte(trueEmberVersion, '2.3.0') ||
+      parentChecker.for('ember-getowner-polyfill', 'npm').gte('1.1.0'),
+    SUPPORTS_SET_OWNER: gte(trueEmberVersion, '2.3.0'),
+    SUPPORTS_NEW_COMPUTED: gte(trueEmberVersion, '1.12.0-beta.1'),
+    SUPPORTS_INVERSE_BLOCK: gte(trueEmberVersion, '1.13.0'),
+    SUPPORTS_CLOSURE_ACTIONS: gte(trueEmberVersion, '1.13.0'),
+    SUPPORTS_UNIQ_BY_COMPUTED: gte(trueEmberVersion, '2.7.0')
+  };
+};


### PR DESCRIPTION
This PR extracts the flags definitions for the debug plugin into a separate file, so that a TypeScript declaration file can be generated from them in the `prepack` step, that is executed right before the addon is published to npm.